### PR TITLE
fix:회원가입과 로그인 API 통합: 소셜 로그인 시 social_id로 기존 유저 여부를 체크하여 분기 처리

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,8 +1,21 @@
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 
 from app.routers import auth, easter_egg, users
 
 app = FastAPI()
+
+origins = [
+    "http://localhost:3000",
+]
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 # Http 엔드포인트
 app.include_router(auth.router)

--- a/app/routers/auth.py
+++ b/app/routers/auth.py
@@ -1,6 +1,6 @@
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends, Header, Request
 
 from app.core.base import BaseResponse
 from app.core.database import get_db
@@ -25,49 +25,26 @@ async def kakao_callback(req: Request):
     return {"code": code}
 
 
-@router.post("/signup", response_model=BaseResponse)
-async def sign_up(
+@router.post("/signin", response_model=BaseResponse)
+async def sign_in(
     req: AuthDtoModel,
-    headers: Annotated[CommonHeader, Depends()],
-    db=Depends(get_db),
-) -> BaseResponse:
-    """회원 가입 API"""
-    auth = AuthService()
-
-    # 로그인 타입에 따른 user_dat 분기처리
-    if req.login_type == "KAKAO":
-        social_user = await auth.get_kakao_user_info(access_token=headers.access_token)
-        user_data = {**req.model_dump(), **social_user.model_dump()}
-
-    # 신규유저 데이터 생성 후 user id값 반환
-    user = UserService(db=db)
-    user_id = await user.signup_new_user(user_data=user_data)
-
-    # user id값으로 jwt token 생성
-    data = {
-        "sub": f"{user_id}",
-    }
-    access_token = create_jwt_access_token(data=data)
-    refresh_token = create_jwt_refresh_token(data=data)
-
-    token = {**access_token, **refresh_token}
-
-    return BaseResponse(status_code=200, data=token)
-
-
-@router.post("/signin")
-async def signin(
-    req: AuthDtoModel,
-    headers: Annotated[CommonHeader, Depends()],
+    access_token: str = Header(...),
+    refresh_token: str = Header(...),
     db=Depends(get_db),
 ):
-    auth = AuthService()
-    if req.login_type == "KAKAO":
-        social_user = await auth.get_kakao_user_info(access_token=headers.access_token)
-        social_id = social_user.social_id
-
+    """소셜ID값으로 회원여부를 확인하고, 없으면 가입 후 자체 JWT 발급하는 API."""
     user = UserService(db=db)
-    user_id = await user.get_user_id(social_id=social_id)
+    is_registered = await user.is_registered_user(social_id=req.social_id)
+
+    auth = AuthService()
+    if is_registered:
+        social_user = await auth.get_kakao_user_info(access_token=access_token)
+        social_id = social_user.social_id
+        user_id = await user.get_user_id(social_id=social_id)
+    else:
+        social_user = await auth.get_kakao_user_info(access_token=access_token)
+        user_data = {**req.model_dump(), **social_user.model_dump()}
+        user_id = await user.signup_new_user(user_data=user_data)
 
     data = {
         "sub": f"{user_id}",

--- a/app/schemas/auth.py
+++ b/app/schemas/auth.py
@@ -10,6 +10,7 @@ class AuthDtoModel(BaseModel):
     """회원가입, 로그인 DTO"""
 
     login_type: str = Field(..., description="로그인 유형 (KAKAO, EMAIL)")
+    social_id: str | None = Field(None, description="소셜로그인 시 id값")
     email: str | None = Field(
         None,
         description="이메일 주소 (이메일 로그인일 경우 필수)",

--- a/app/services/users.py
+++ b/app/services/users.py
@@ -18,6 +18,13 @@ class UserService:
     def __init__(self, db=None):
         self.db = db
 
+    async def is_registered_user(self, social_id: str) -> bool:
+        """회원가입된 유저여부를 반환하는 메소드."""
+        user = self.db.query(Users.id).filter(Users.social_id == social_id).first()
+        if user is None:
+            return False
+        return True
+
     async def signup_new_user(self, user_data):
         """신규유저 생성 메소드."""
         try:
@@ -51,3 +58,39 @@ class UserService:
         if user_id is None:
             raise NotFoundError(detail="해당 사용자를 찾을 수 없습니다.")
         return user_id
+
+    def get_my_info(self, user_id: int):
+        """user_id값으로 내 정보 가져오기"""
+        user = (
+            self.db.query(
+                Users.email,
+                Users.social_id,
+                Users.login_type,
+                Users.profile_image,
+                Users.nickname,
+            )
+            .filter(Users.id == user_id)
+            .first()
+        )
+        if user is None:
+            raise NotFoundError(detail="해당 사용자를 찾을 수 없습니다.")
+        return columns_to_dict(user)
+
+    def create_profile(self, profile: CreateProfileDTO):
+        """프로필 생성
+
+        Args:
+            profile (CreateProfileDTO): 닉네임과 유저의 프로필 이미지
+        """
+        try:
+            stmt = (
+                update(Users)
+                .where(Users.id == profile.user_id)
+                .values(nickname=profile.nickname, profile_image=profile.profile_image)
+            )
+            self.db.execute(stmt)
+        except DataError as e:
+            raise SQLDataErrorException(detail=f"입력하신 정보가 너무 깁니다.")
+        except SQLAlchemyError as e:
+            raise SQLAlchemyError(f"{str(e)}")
+        return dict(nickname=profile.nickname, profile_image=profile.profile_image)


### PR DESCRIPTION
## 📌 작업 내용
- 해당 PR에서 작업한 내용을 간략하게 정리
> 회원가입과 로그인 API 통합: 소셜 로그인 시 social_id로 기존 유저 여부를 체크하여 분기 처리

## 📑 상세 작업 내용
- 보다 구체적인 변경 사항 설명
1. 기존에 회원가입과 로그인 API를 따로 만들었었지만, 소셜 로그인 방식에서는 두 API를 구분하기 어려워서 이를 통합시킴
- 통합 방식은 social_id 값을 기준으로 회원가입된 유저인지 아닌지를 먼저 체크하고, 그 여부에 따라 회원가입 로직을 실행할지 로그인 로직을 실행할지를 분기처리하는 방식으로 

## 💬 기타 사항
- 리뷰어가 알아야 할 추가적인 내용이 있다면 여기에 작성


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 서버에 CORS 지원이 추가되어, 지정된 출처에서 안전하게 요청을 처리할 수 있습니다.
  - 인증 로직이 통합되어, 기존 사용자와 신규 사용자를 하나의 로그인 엔드포인트로 지원합니다.
  - 소셜 로그인 기능이 강화되어, 소셜 인증을 위한 식별 정보가 추가되었습니다.
  - 사용자 정보 조회 및 프로필 업데이트 기능이 개선되어, 보다 원활한 프로필 관리가 가능합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->